### PR TITLE
exe: fix and test PKG type marker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,9 @@ jobs:
       run: pip install -r requirements.txt
     - name: Download dvc pkg
       run: python download.py
+    - name: Set pkg type
+      shell: bash
+      run: echo 'PKG = "exe"' > dvc/dvc/_build.py
     - name: Install dvc requirements
       run: |
         pip install .\dvc[all]
@@ -31,9 +34,6 @@ jobs:
         # https://github.com/iterative/dvc/issues/9654
         pip install flufl-lock==7.1.1
         dvc doctor
-    - name: Set pkg type
-      shell: bash
-      run: echo 'PKG = "exe"' > dvc/_build.py
     - name: Build binary
       run: python build_bin.py
     - name: Pull images

--- a/build_bin.py
+++ b/build_bin.py
@@ -40,5 +40,6 @@ remotes = [
 ]
 
 print(out)
+assert "(exe)" in out.splitlines()[0]
 for remote in remotes:
     assert f"\t{remote}" in out, f"Missing support for {remote}"


### PR DESCRIPTION
Currently we are generating `_build.py` one level above where it is needed, resulting in `dvc doctor` not picking it up. And we were also generating it after installing dvc, which didn't affect the installation. 